### PR TITLE
NEOR-16: Add full assembly location

### DIFF
--- a/src/CSharpScript.cs
+++ b/src/CSharpScript.cs
@@ -95,7 +95,7 @@ namespace Sovos.Scripting
       AddReferencedAssembly("SYSTEM.DLL");
       AddReferencedAssembly("SYSTEM.CORE.DLL");
       AddReferencedAssembly("MICROSOFT.CSHARP.DLL");
-      AddReferencedAssembly(Path.GetFileName(GetType().Assembly.Location));
+      AddReferencedAssembly(GetType().Assembly.Location);
       objectsInScope = new Dictionary<string, object>();
       usesNamespaces = new List<string> { "System", "System.Dynamic", "Sovos.Scripting.CSharpScriptObjectBase", "System.Collections.Generic" };
       expressions = new List<string>();


### PR DESCRIPTION
When using this as a DLL, it needs the full path to itself. This is because the process that uses the DLL might be started from another directory and then the DLL can't find itself. This also applies to any other DLLs that are used that aren't in the PATH.